### PR TITLE
Check for users that are active but have a past expiration date

### DIFF
--- a/tests/commands/check/samples/ok_active.csv
+++ b/tests/commands/check/samples/ok_active.csv
@@ -1,0 +1,3 @@
+username,externalSystemId,active,expirationDate
+user1,user1@external.com,false,2023-08-04
+user2,user2@external.com,true,2099-08-04

--- a/tests/commands/check/samples/schema_active_expired.csv
+++ b/tests/commands/check/samples/schema_active_expired.csv
@@ -1,0 +1,4 @@
+#||active_expired
+username,externalSystemId,active,expirationDate
+user1,user1@external.com,true,2023-08-04
+user2,user2@external.com,


### PR DESCRIPTION
While testing the import I noticed that there are users which are both active and have an expiration date in the past. They get imported as active but then FOLIO deactivates them shortly after. This isn't a validation issue but a more of a warning? I wonder if this should be raised separately somehow.